### PR TITLE
Fix cart interactions and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ecommerce-frontend/src/App.js
+++ b/ecommerce-frontend/src/App.js
@@ -33,6 +33,23 @@ function App() {
       });
   };
 
+  const fetchShoppingCart = (cartId) => {
+    fetch(`http://localhost:3001/carrinho-de-compras/${cartId}`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('Falha ao obter carrinho');
+        }
+        return response.json();
+      })
+      .then(data => setCart(data))
+      .catch(error => {
+        console.error('Erro ao obter carrinho:', error);
+        setSnackbarMessage('Erro ao atualizar o carrinho.');
+        setSnackbarSeverity('error');
+        setSnackbarOpen(true);
+      });
+  };
+
   const handleAddToCartApp = (product) => {
     if (!cart || !cart.id) {
       setSnackbarMessage('Carrinho não inicializado. Tente novamente.');
@@ -62,8 +79,8 @@ function App() {
         }
         return response.json();
       })
-      .then(updatedCartItem => {
-        createShoppingCart();
+      .then(() => {
+        fetchShoppingCart(cart.id);
         setSnackbarMessage(`"${product.nome}" adicionado ao carrinho!`);
         setSnackbarSeverity('success');
         setSnackbarOpen(true);
@@ -96,7 +113,7 @@ function App() {
         return response.text().then(text => text ? JSON.parse(text) : {});
       })
       .then(() => {
-        createShoppingCart();
+        fetchShoppingCart(cart.id);
         setSnackbarMessage('Item removido do carrinho.');
         setSnackbarSeverity('success');
         setSnackbarOpen(true);

--- a/ecommerce-frontend/src/App.test.js
+++ b/ecommerce-frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders application header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Meu Ecommerce/i);
+  expect(header).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix shopping cart state refresh on add/remove product
- add function to fetch current cart
- simplify frontend test to look for header text
- add a root `.gitignore`

## Testing
- `CI=true npm test --silent` within `ecommerce-frontend`
- `npm test` within `ecommerce-backend-nestJS`

------
https://chatgpt.com/codex/tasks/task_e_685b0d40b448832b83e832fb2a3e42f9