### PR TITLE
Add default admin user creation

### DIFF
--- a/ecommerce-backend-nestJS/README.md
+++ b/ecommerce-backend-nestJS/README.md
@@ -58,6 +58,10 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+Upon first startup, the backend checks for a user named `admin` and, if absent,
+creates it automatically with password `senha123`. You can use these credentials
+to log in.
+
 ## Run tests
 
 ```bash

--- a/ecommerce-backend-nestJS/src/main.ts
+++ b/ecommerce-backend-nestJS/src/main.ts
@@ -1,8 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { UsersService } from './users/users.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  await app.init();
+  const usersService = app.get(UsersService);
+  const admin = await usersService.findByUsername('admin');
+  if (!admin) {
+    await usersService.create('admin', 'senha123');
+    console.log('Default admin user created');
+  }
   app.enableCors({ origin: 'http://localhost:3000' });
   await app.listen(process.env.PORT ?? 3001);
 }


### PR DESCRIPTION
## Summary
- create an admin user automatically at startup if none exists
- document default admin credentials in backend README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643e717b64832b83fdd5e6b6e6f143