### PR TITLE
Improve frontend look with custom theme

### DIFF
--- a/ecommerce-frontend/src/index.css
+++ b/ecommerce-frontend/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #f5f5f5;
 }
 
 code {

--- a/ecommerce-frontend/src/index.js
+++ b/ecommerce-frontend/src/index.js
@@ -3,11 +3,28 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import { deepPurple, amber } from '@mui/material/colors';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: deepPurple[500],
+    },
+    secondary: {
+      main: amber[500],
+    },
+  },
+});
+
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- tweak Material UI palette with purple/orange colors
- lighten page background

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686442b3fe98832bb8a594ab89e4dfd3