### PR TITLE
Add auth microservice

### DIFF
--- a/auth-service/README.md
+++ b/auth-service/README.md
@@ -1,0 +1,19 @@
+# Auth Service
+
+This is a simple authentication microservice with a mocked user.
+
+## Backend
+Run the backend:
+```bash
+cd backend
+npm install
+npm start
+```
+The server runs on port `3002` by default.
+
+## Frontend
+A minimal frontend is served by the backend automatically. After starting the backend, open [`http://localhost:3002`](http://localhost:3002) in your browser to access the login page.
+
+Credentials:
+- **username:** `admin`
+- **password:** `senha123`

--- a/auth-service/backend/package.json
+++ b/auth-service/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "auth-service-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "cors": "^2.8.5",
+    "body-parser": "^1.20.2"
+  }
+}

--- a/auth-service/backend/server.js
+++ b/auth-service/backend/server.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import cors from 'cors';
+import bodyParser from 'body-parser';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+app.use(cors());
+app.use(bodyParser.json());
+
+const SECRET = process.env.JWT_SECRET || 'authsecret';
+const PORT = process.env.PORT || 3002;
+
+// Serve the frontend
+app.use(express.static('../frontend'));
+
+// Mocked user credentials
+const adminUser = {
+  username: 'admin',
+  password: 'senha123'
+};
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === adminUser.username && password === adminUser.password) {
+    const token = jwt.sign({ username }, SECRET, { expiresIn: '1d' });
+    return res.json({ access_token: token });
+  }
+  res.status(401).json({ message: 'Invalid credentials' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Auth service listening on port ${PORT}`);
+});

--- a/auth-service/frontend/index.html
+++ b/auth-service/frontend/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Auth Service Login</title>
+</head>
+<body>
+  <h1>Login</h1>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="Username" required />
+    <input type="password" id="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const username = document.getElementById('username').value;
+      const password = document.getElementById('password').value;
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>

--- a/ecommerce-frontend/src/components/Login.jsx
+++ b/ecommerce-frontend/src/components/Login.jsx
@@ -7,7 +7,7 @@ export default function Login({ onLoggedIn }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    fetch('http://localhost:3001/auth/login', {
+    fetch('http://localhost:3002/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),


### PR DESCRIPTION
## Summary
- add `auth-service` microservice with express backend and minimal HTML frontend
- update login component to call the new microservice

## Testing
- `npm test` in `ecommerce-backend-nestJS` *(fails: jest not found)*
- `npm test` in `ecommerce-frontend` *(fails: react-scripts not found)*
- `npm test` in `auth-service/backend` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6865c474b6b4832b8285b490a42bc90e